### PR TITLE
Support recent version Carthage outputs

### DIFF
--- a/lib/anticuado/ios/carthage.rb
+++ b/lib/anticuado/ios/carthage.rb
@@ -23,13 +23,24 @@ module Anticuado
         return [] if index.nil?
 
         array[index + 1..array.size].map do |library|
-          versions = library.split(/[\s|"]/) # e.g. ["Result", "", "2.0.0", "", "->", "", "2.1.3"]
-          {
+          versions = library.split(/[\s|"]/) 
+          if versions[8] =~ /Latest/
+            # e.g. ["RxSwift", "", "4.1.0", "", "->", "", "4.1.2", "", "(Latest:", "", "4.1.2", ")"]
+            {
+              library_name: versions[0],
+              current_version: versions[2],
+              available_version: versions[6],
+              latest_version: versions[10]
+            }
+          else
+            # e.g. ["Result", "", "2.0.0", "", "->", "", "2.1.3"]
+            {
               library_name: versions[0],
               current_version: versions[2],
               available_version: versions[6],
               latest_version: versions[6]
-          }
+            }
+          end
         end
       end
     end # class Carthage

--- a/test/anticuado/ios/carthage_test.rb
+++ b/test/anticuado/ios/carthage_test.rb
@@ -11,6 +11,13 @@ The following dependencies are outdated:
 Result "2.0.0" -> "2.1.3"
       OUTDATED
 
+
+      OUTDATED_HAVE_UPDATE_WITH_LATEST =<<-OUTDATED
+*** Fetching Puree-Swift
+The following dependencies are outdated:
+Puree-Swift "3.0.0" -> "3.0.0" (Latest: "3.1.1")
+      OUTDATED
+
       OUTDATED_NO_UPDATE =<<-OUTDATED
 *** Fetching Result
 *** Fetching Himotoki
@@ -22,6 +29,14 @@ All dependencies are up to date.
         result = Anticuado::IOS::Carthage.format OUTDATED_HAVE_UPDATE
 
         expected_0 = { library_name: "Result", current_version: "2.0.0", available_version: "2.1.3", latest_version: "2.1.3" }
+
+        assert_equal expected_0, result[0]
+      end
+
+      def test_with_format_have_update_with_latest
+        result = Anticuado::IOS::Carthage.format OUTDATED_HAVE_UPDATE_WITH_LATEST
+
+        expected_0 = { library_name: "Puree-Swift", current_version: "3.0.0", available_version: "3.0.0", latest_version: "3.1.1" }
 
         assert_equal expected_0, result[0]
       end


### PR DESCRIPTION
Recent version of Carhage outputs like following:

```console
$ carthage outdated
*** Fetching RxSwift
The following dependencies are outdated:
RxSwift "4.1.0" -> "4.1.2" (Latest: "4.1.2")
```

So I made the parser to support this syntax.